### PR TITLE
Factored WebSocket handling out of OrderBook to allow for easy creation of custom order book implementations

### DIFF
--- a/gdax/__init__.py
+++ b/gdax/__init__.py
@@ -1,3 +1,4 @@
 import gdax.orderbook
 import gdax.trader
 import gdax.utils
+import gdax.websocket_feed_listener

--- a/gdax/websocket_feed_listener.py
+++ b/gdax/websocket_feed_listener.py
@@ -1,0 +1,118 @@
+"""
+Base class for listening to web socket feed messages based on GDAX's Websocket endpoint.
+
+See: https://docs.gdax.com/#websocket-feed.
+
+"""
+
+import asyncio
+import json
+
+import time
+
+import aiofiles
+import aiohttp
+
+import gdax.utils
+
+from abc import ABC, abstractmethod
+
+
+class WebSocketFeedListener(ABC):
+    def __init__(self, product_ids='ETH-USD', channels=None, api_key=None, api_secret=None,
+                 passphrase=None, use_heartbeat=False,
+                 trade_log_file_path=None):
+        if api_key is not None:
+            self._authenticated = True
+            self.api_key = api_key
+            self.api_secret = api_secret
+            self.passphrase = passphrase
+        else:
+            self._authenticated = False
+
+        if not isinstance(product_ids, list):
+            product_ids = [product_ids]
+        self.product_ids = product_ids
+
+        self.channels = None
+        if channels is not None:
+            if not isinstance(channels, list):
+                channels = [channels]
+            self.channels = channels
+
+        self.use_heartbeat = use_heartbeat
+        self.trade_log_file_path = trade_log_file_path
+        self._trade_file = None
+
+        self._ws_session = None
+        self._ws_connect = None
+        self._ws = None
+
+    async def _init(self):
+        self._ws_session = aiohttp.ClientSession()
+        self._ws_connect = self._ws_session.ws_connect(
+            'wss://ws-feed.gdax.com')
+        self._ws = await self._ws_connect.__aenter__()
+
+        # subscribe
+        await self._subscribe()
+
+        if self.use_heartbeat:
+            await self._send(type="heartbeat", on=True)
+
+    async def __aenter__(self):
+        await asyncio.gather(self._init(), self._open_log_file())
+
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        res = await asyncio.gather(
+            self._ws_session.__aexit__(exc_type, exc, traceback),
+            self._close_log_file(),
+        )
+        return res[0]
+
+    async def _open_log_file(self):
+        if self.trade_log_file_path is not None:
+            self._trade_file = await aiofiles.open(self.trade_log_file_path,
+                                                   mode='a').__aenter__()
+
+    async def _close_log_file(self):
+        if self._trade_file is not None:
+            await self._trade_file.__aexit__(None, None, None)
+
+    async def _send(self, **kwargs):
+        await self._ws.send_json(kwargs)
+
+    async def _recv(self):
+        json_data = await self._ws.receive_str()
+        if self._trade_file:
+            await self._trade_file.write(f'W {json_data}\n')
+        return json.loads(json_data)
+
+    async def _subscribe(self):
+        message = {
+            'type': 'subscribe',
+            'product_ids': self.product_ids,
+        }
+
+        if self.channels is not None:
+            message['channels'] = self.channels
+
+        if self._authenticated:
+            path = '/users/self'
+            method = 'GET'
+            body = ''
+            timestamp = str(time.time())
+
+            message['signature'] = gdax.utils.get_signature(
+                path, method, body, timestamp, self.api_secret)
+            message['timestamp'] = timestamp
+            message['key'] = self.api_key
+            message['passphrase'] = self.passphrase
+
+        return await self._send(**message)
+
+    @abstractmethod
+    async def handle_message(self):
+        pass


### PR DESCRIPTION
For my own work I needed to modify your code to subscribe to the ticker channel instead of the full orderbook. Your OrderBook code was already well segmented into code that dealt with the Websocket and code that implemented the actual order book. So rather than modify your code I factored the Websocket code out into an abstract base class and then changed your OrderBook class to inherit from it.  Now anyone with your API wrapper can easily inherit from WebSocketFeedListener to create their own order book, ticker, or level2 implementations without having to modify your API.

Since the OrderBook still has the same class signature as it originally did, your tests cases all pass without any changes to them. Happy to make changes if you see something you don't like. Details on each change below:

*****************************
**WebSocketFeedListener**
*****************************
Factored the web socket code away from the actual orderbook
implementation. The new WebSocketFeedListener is an abstract base class
that handles the websocket itself including:

- Connect
- Disconnect
- Send / Receive messages
- Subscribing to channels
- Leveraging the trade log file
- Async Context Manager calls

WebSocketFeedListener inherits from ABC and has a single @abstractmethod
handle_message(self), which must be implemented by subclasses.

******************************
**OrderBook**
******************************

Removed all WebSocket manipulation from OrderBook and left just the
OrderBook implementation. OrderBook now inherits from
WebSocketFeedListener and implements handle_message.