### PR TITLE
deprecate bintrees in favor of sortedcontainers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 aiofiles==0.3.1
 aiohttp==2.2.0
 async_timeout==1.2.1
-bintrees==2.0.7
+sortedcontainers==1.5.9


### PR DESCRIPTION
@csko First off, this is an awesome repo, thanks for putting it out there.

In studying this code base, I found that bintrees (https://github.com/mozman/bintrees) is no longer in development and the author is now promoting use of sortedcontainers (https://pypi.python.org/pypi/sortedcontainers). In all honesty, I made these modifications for my own learning benefit, but I thought you might be interested in taking a look.


