### PR TITLE
use ujson over json because json.dumps() cannot serialize Decimal

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ You can [download the latest release from Github](https://github.com/csko/gdax-p
 * aiofiles
 * async_timeout
 * sortedcontainers
+* ujson
 
 
 ## Acknowledgements

--- a/gdax/orderbook.py
+++ b/gdax/orderbook.py
@@ -6,7 +6,7 @@ See: https://docs.gdax.com/#websocket-feed.
 
 import asyncio
 from decimal import Decimal
-import json
+import ujson as json
 import logging
 from operator import itemgetter
 

--- a/gdax/trader.py
+++ b/gdax/trader.py
@@ -6,7 +6,7 @@ JSON client for interacting with api.gdax.com.
 
 import copy
 from decimal import Decimal, InvalidOperation
-import json
+import ujson as json
 import logging
 import time
 

--- a/gdax/websocket_feed_listener.py
+++ b/gdax/websocket_feed_listener.py
@@ -6,7 +6,7 @@ See: https://docs.gdax.com/#websocket-feed.
 """
 
 import asyncio
-import json
+import ujson as json
 
 import time
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ aiofiles==0.3.1
 aiohttp==2.2.0
 async_timeout==1.2.1
 sortedcontainers==1.5.9
+ujson==1.35

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
         'aiofiles==0.3.1',
         'async_timeout==1.2.1',
         'sortedcontainers==1.5.9',
+        'ujson==1.35',
       ],
       packages=find_packages(),
       include_package_data=True,

--- a/tests/test_orderbook.py
+++ b/tests/test_orderbook.py
@@ -1,5 +1,5 @@
 import copy
-import json
+import ujson as json
 import base64
 from decimal import Decimal
 


### PR DESCRIPTION
@csko I was running into errors with `json.dumps()` used here: https://github.com/davluangu/gdax-python-api/blob/76d9685a03e5f6404c13101c24c5cd45aec600b1/gdax/orderbook.py#L57
The issue is that `json.dumps()` cannot deal with `Decimal()` types. This is only an issue when using the `trade_log_file_path` arg in `OrderBook()`.

Here's a toy example of the error:

```python
import json
from decimal import Decimal

json.dumps({
    'bids': [[Decimal('849.6'), Decimal('0.002'), 'b06193b0-8a8e-47a9-9385-b9bzfa55d1db']],
    'asks': [[Decimal('849.61'), Decimal('0.00241623'), 'b8546721-3988-4210-9f83-e093fff86e1a']]    
})
```

output:
```python
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-afb1ff756b46> in <module>()
      8 }
      9
---> 10 json.dumps(book)

~/.pyenv/versions/3.6.3/lib/python3.6/json/__init__.py in dumps(obj, skipkeys, ensure_ascii, check_circular, allow_nan, cls, indent, separators, default, sort_keys, **kw)
    229         cls is None and indent is None and separators is None and
    230         default is None and not sort_keys and not kw):
--> 231         return _default_encoder.encode(obj)
    232     if cls is None:
    233         cls = JSONEncoder

~/.pyenv/versions/3.6.3/lib/python3.6/json/encoder.py in encode(self, o)
    197         # exceptions aren't as detailed.  The list call should be roughly
    198         # equivalent to the PySequence_Fast that ''.join() would do.
--> 199         chunks = self.iterencode(o, _one_shot=True)
    200         if not isinstance(chunks, (list, tuple)):
    201             chunks = list(chunks)

~/.pyenv/versions/3.6.3/lib/python3.6/json/encoder.py in iterencode(self, o, _one_shot)
    255                 self.key_separator, self.item_separator, self.sort_keys,
    256                 self.skipkeys, _one_shot)
--> 257         return _iterencode(o, 0)
    258
    259 def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,

~/.pyenv/versions/3.6.3/lib/python3.6/json/encoder.py in default(self, o)
    178         """
    179         raise TypeError("Object of type '%s' is not JSON serializable" %
--> 180                         o.__class__.__name__)
    181
    182     def encode(self, o):

TypeError: Object of type 'Decimal' is not JSON serializable
```

The fix is quite simple, just use `ujson` (https://pypi.python.org/pypi/ujson) instead of `json`:
```python
import ujson as json
```
Here's how you can recreate the actual error when using `OrderBook()`. It is basically the same code you have in `main` in orderbook.py with the uncommented line that sets `trade_log_file_path`:
```python
import asyncio
from decimal import Decimal
from gdax.orderbook import OrderBook

async def run_orderbook():  # pragma: no cover
    async with OrderBook(
        ['ETH-USD', 'BTC-USD'],
        api_key=None,
        api_secret=None,
        passphrase=None,
        trade_log_file_path='trades.txt',
    ) as orderbook:
        while True:
            message = await orderbook.handle_message()
            if message is None:
                continue
            product_id = message['product_id']

loop = asyncio.get_event_loop()
loop.run_until_complete(run_orderbook())

```
